### PR TITLE
Replace `decorateRequest` by `onRequest` hook

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -40,11 +40,17 @@ const plugin = async (fastify, options) => {
     route: createRoute(fastify, routes)
   });
 
-  // Decorate request.
-  fastify.decorateRequest(DECORATOR_NAME, {
-    operation: {},
-    security: {},
-    securityReport: []
+  // Avoid decorating the request with reference types.
+  // Any mutation will impact all requests.
+  fastify.decorateRequest(DECORATOR_NAME, null);
+
+  // Instead, decorate each incoming request.
+  fastify.addHook('onRequest', async request => {
+    request[DECORATOR_NAME] = {
+      operation: {},
+      security: {},
+      securityReport: []
+    };
   });
 };
 


### PR DESCRIPTION
Resolve deprecation warning triggered by Fastify when decorating the Request with a reference type.

```
DeprecationWarning: You are decorating Request/Reply with a reference type. This reference is shared amongst all requests. Use onRequest hook instead. Property: oas
```

This replaces the `fastify.decorateRequest()` with the `fastify.addHook('onRequest', ...)`.