### PR TITLE
Call `securityHandlers` and `securityErrorMapper` with req and operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ await fastify.register(import('@fastify/fastify-openapi-router-plugin'), {
     }
   },
   securityHandlers: {
-    OAuth2: async (token, request) => {
+    OAuth2: async (token, request, operation) => {
       // Validate and decode token.
       const { userId } = verifyToken(token);
 
@@ -154,7 +154,7 @@ await fastify.register(import('@fastify/fastify-openapi-router-plugin'), {
       // ...
     }
   },
-  securityErrorMapper: (unauthorizedError) => {
+  securityErrorMapper: (unauthorizedError, request, operation) => {
     // Use `unauthorizedError.securityReport` to perform logic and return a custom error.
     return MyUnauthorizedError();
   },

--- a/src/parser/security.js
+++ b/src/parser/security.js
@@ -40,7 +40,7 @@ export const applySecurity = (operation, spec, securityHandlers, securityErrorMa
       let promise = promisesCache.get(name);
 
       if (!promise) {
-        promise = new Promise(resolve => resolve(securityHandlers[name](value, request)));
+        promise = new Promise(resolve => resolve(securityHandlers[name](value, request, operation)));
         promisesCache.set(name, promise);
       }
 
@@ -95,7 +95,7 @@ export const applySecurity = (operation, spec, securityHandlers, securityErrorMa
     if (!lastResult.ok) {
       const error = createUnauthorizedError(report);
 
-      throw securityErrorMapper?.(error) ?? error;
+      throw securityErrorMapper?.(error, request, operation) ?? error;
     }
 
     // Otherwise, we can safely use the last result to decorate the request.

--- a/src/parser/security.test.js
+++ b/src/parser/security.test.js
@@ -130,9 +130,9 @@ describe('applySecurity()', () => {
     await onRequest(request);
 
     expect(securityHandlers.ApiKey).toHaveBeenCalledTimes(1);
-    expect(securityHandlers.ApiKey).toHaveBeenCalledWith('api key', request);
+    expect(securityHandlers.ApiKey).toHaveBeenCalledWith('api key', request, operation);
     expect(securityHandlers.OAuth2).toHaveBeenCalledTimes(1);
-    expect(securityHandlers.OAuth2).toHaveBeenCalledWith('bearer token', request);
+    expect(securityHandlers.OAuth2).toHaveBeenCalledWith('bearer token', request, operation);
     expect(securityHandlers.ApiKey2).not.toHaveBeenCalled();
     expect(request[DECORATOR_NAME].security).toMatchObject({ ApiKey: 'ApiKey data', OAuth2: 'OAuth2 data' });
     expect(request[DECORATOR_NAME].securityReport).toMatchInlineSnapshot(`
@@ -185,9 +185,9 @@ describe('applySecurity()', () => {
     await onRequest(request);
 
     expect(securityHandlers.ApiKey).toHaveBeenCalledTimes(1);
-    expect(securityHandlers.ApiKey).toHaveBeenCalledWith('api key', request);
+    expect(securityHandlers.ApiKey).toHaveBeenCalledWith('api key', request, operation);
     expect(securityHandlers.OAuth2).toHaveBeenCalledTimes(1);
-    expect(securityHandlers.OAuth2).toHaveBeenCalledWith('bearer token', request);
+    expect(securityHandlers.OAuth2).toHaveBeenCalledWith('bearer token', request, operation);
     expect(request[DECORATOR_NAME].security).toMatchObject({ OAuth2: 'OAuth2 data' });
     expect(request[DECORATOR_NAME].securityReport).toMatchInlineSnapshot(`
       [
@@ -554,7 +554,7 @@ describe('applySecurity()', () => {
     } catch (err) {
       expect(err).toBe(customError);
       expect(securityErrorMapper).toHaveBeenCalledTimes(1);
-      expect(securityErrorMapper.mock.calls[0][0]).toBeInstanceOf(errors.UnauthorizedError);
+      expect(securityErrorMapper).toHaveBeenCalledWith(expect.any(errors.UnauthorizedError), request, operation);
     }
   });
 });


### PR DESCRIPTION
So that we can use operation's custom properties in logic.