### PR TITLE
Remove `discriminator` from body

### DIFF
--- a/src/parser/body.js
+++ b/src/parser/body.js
@@ -12,7 +12,7 @@ export const parseBody = (route, operation) => {
   addPropertyToSchema(route.schema.headers, { 'content-type': { const: contentType } }, true);
 
   // Sanitize schema.
-  removeAttributesFromSchema(schema, ['xml', 'example']);
+  removeAttributesFromSchema(schema, ['xml', 'example', 'discriminator']);
 
   // Add request body schema.
   route.schema.body = schema;

--- a/src/parser/body.test.js
+++ b/src/parser/body.test.js
@@ -71,6 +71,7 @@ describe('parseBody()', () => {
 
   it('should sanitize body schema', () => {
     const schema = {
+      bar: { discriminator: { propertyName: 'type' }, type: 'object' },
       foo: { example: 'baz', type: 'string', xml: { name: 'foo' } },
       required: ['foo'],
       xml: { name: 'Bar' }
@@ -84,6 +85,7 @@ describe('parseBody()', () => {
     parseBody(route, { requestBody });
 
     expect(route.schema.body).toStrictEqual({
+      bar: { type: 'object' },
       foo: { type: 'string' },
       required: ['foo']
     });


### PR DESCRIPTION
Remove `discriminator` from body since fastify complains it doesn't support it