### PR TITLE
Remove only `discriminator.mapping`

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,22 @@ This plugin configures Fastify to coerce `parameters` to the correct type based 
 
 If your API needs improved coercion support, like `object` types or `cookie` parameters, please [fill an issue](https://github.com/uphold/fastify-openapi-router-plugin/issues/new) to discuss the implementation.
 
+#### Using `discriminator`
+
+This plugin removes `discriminator.mapping` from schemas since `ajv` (fastify's validator) does not support it. However, to use `discriminator` in your OpenAPI schema, you must also enable `discriminator` option during fastify initialization like so:
+
+```js
+import Fastify from 'fastify'
+
+const fastify = Fastify({
+  ajv: {
+    customOptions: {
+      discriminator: true
+    }
+  }
+});
+```
+
 ## License
 
 [MIT](./LICENSE)

--- a/src/parser/body.js
+++ b/src/parser/body.js
@@ -12,7 +12,7 @@ export const parseBody = (route, operation) => {
   addPropertyToSchema(route.schema.headers, { 'content-type': { const: contentType } }, true);
 
   // Sanitize schema.
-  removeAttributesFromSchema(schema, ['xml', 'example', 'discriminator']);
+  removeAttributesFromSchema(schema, ['xml', 'example', 'discriminator.mapping']);
 
   // Add request body schema.
   route.schema.body = schema;

--- a/src/parser/body.test.js
+++ b/src/parser/body.test.js
@@ -71,8 +71,18 @@ describe('parseBody()', () => {
 
   it('should sanitize body schema', () => {
     const schema = {
-      bar: { discriminator: { propertyName: 'type' }, type: 'object' },
-      foo: { example: 'baz', type: 'string', xml: { name: 'foo' } },
+      bar: {
+        discriminator: {
+          mapping: { bar: 'baz', foo: 'foz' },
+          propertyName: 'type'
+        },
+        type: 'object'
+      },
+      foo: {
+        example: 'baz',
+        type: 'string',
+        xml: { name: 'foo' }
+      },
       required: ['foo'],
       xml: { name: 'Bar' }
     };
@@ -85,7 +95,10 @@ describe('parseBody()', () => {
     parseBody(route, { requestBody });
 
     expect(route.schema.body).toStrictEqual({
-      bar: { type: 'object' },
+      bar: {
+        discriminator: { propertyName: 'type' },
+        type: 'object'
+      },
       foo: { type: 'string' },
       required: ['foo']
     });

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -1,3 +1,5 @@
+import { unset } from 'lodash-es';
+
 export const addPropertyToSchema = (schema, properties, required) => {
   for (const key in properties) {
     const property = properties[key];
@@ -19,10 +21,12 @@ export const removeAttributesFromSchema = (schema, attributes) => {
     return;
   }
 
+  for (const attribute of attributes) {
+    unset(schema, attribute);
+  }
+
   for (const prop in schema) {
-    if (attributes.includes(prop)) {
-      delete schema[prop];
-    } else if (typeof schema[prop] === 'object') {
+    if (typeof schema[prop] === 'object') {
       removeAttributesFromSchema(schema[prop], attributes);
     }
   }

--- a/src/utils/schema.test.js
+++ b/src/utils/schema.test.js
@@ -107,6 +107,13 @@ describe('removeAttributesFromSchema()', () => {
           }
         },
         foo: {
+          discriminator: {
+            mapping: {
+              bar: 'baz',
+              foo: 'foz'
+            },
+            propertyName: 'type'
+          },
           example: 'approved',
           type: 'string'
         }
@@ -115,7 +122,7 @@ describe('removeAttributesFromSchema()', () => {
       xml: { name: 'xml-schema' }
     };
 
-    removeAttributesFromSchema(schema, ['xml', 'example']);
+    removeAttributesFromSchema(schema, ['xml', 'example', 'discriminator.mapping']);
 
     expect(schema).toStrictEqual({
       properties: {
@@ -126,6 +133,7 @@ describe('removeAttributesFromSchema()', () => {
           type: 'string'
         },
         foo: {
+          discriminator: { propertyName: 'type' },
           type: 'string'
         }
       },


### PR DESCRIPTION
#21 removed the whole discriminator object, but actually ajv has limited support for it. It supports `propertyName` but does not support `mapping`, so this PR changes to only remove the `mapping`.