### PR TITLE
Add support for fastify 5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,6 @@ export * from './errors/index.js';
 export { verifyScopes } from './utils/security.js';
 
 export default fp(plugin, {
-  fastify: '4.x',
+  fastify: '4.x||5.x',
   name: PLUGIN_NAME
 });


### PR DESCRIPTION
No need to update the fastify and fastify-plugin dependencies. This way we maintain compatibility with fastify 4.