### PR TITLE
Abort by default if a security handler throws an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ await fastify.register(import('@fastify/fastify-openapi-router-plugin'), {
 });
 ```
 
+Any error thrown by the security handler will be internally wrapped in a `SecurityHandlerError` with `fatal = true`, which will stop further security blocks to be executed. If you wish to continue with the next security block, you can `throw createSecurityHandlerError(error, false)` in your handler.
+
 > [!TIP]
 > The `scopes` returned by the security handler can contain trailing **wildcards**. For example, if the security handler returns `{ scopes: ['pets:*'] }`, the route will be authorized for any security scope that starts with `pets:`.
 
@@ -171,8 +173,8 @@ The `securityReport` property of the unauthorized error contains an array of obj
     schemes: {
       OAuth2: {
         ok: false,
-        // Error thrown by the security handler or fastify.oas.errors.ScopesMismatchError if the scopes were not satisfied.
-        error: new Error(),
+        // The error will be either be a `fastify.oas.errors.SecurityHandlerError` or a `fastify.oas.errors.ScopesMismatchError` if the scopes were not satisfied.
+        error: <Error>,
       }
     }
   }

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,9 +1,11 @@
 import { ScopesMismatchError, createScopesMismatchError } from './scopes-mismatch-error.js';
+import { SecurityHandlerError, createSecurityHandlerError } from './security-handler-error.js';
 import { UnauthorizedError, createUnauthorizedError } from './unauthorized-error.js';
 
 const errors = {
   ScopesMismatchError,
+  SecurityHandlerError,
   UnauthorizedError
 };
 
-export { createScopesMismatchError, createUnauthorizedError, errors };
+export { createScopesMismatchError, createUnauthorizedError, createSecurityHandlerError, errors };

--- a/src/errors/security-handler-error.js
+++ b/src/errors/security-handler-error.js
@@ -1,0 +1,14 @@
+import createError from '@fastify/error';
+
+const SecurityHandlerError = createError('FST_OAS_SECURITY_HANDLER_ERROR', 'Security handler has thrown an error', 403);
+
+const createSecurityHandlerError = (handlerError, fatal = true) => {
+  const err = new SecurityHandlerError();
+
+  err.fatal = fatal;
+  err.cause = handlerError;
+
+  return err;
+};
+
+export { SecurityHandlerError, createSecurityHandlerError };


### PR DESCRIPTION
This is a breaking change, so it should be a major.