### PR TITLE
Add mechanism to install not implemented routes

### DIFF
--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,11 +1,19 @@
+import { NotImplementedError, createNotImplementedError } from './not-implemented-error.js';
 import { ScopesMismatchError, createScopesMismatchError } from './scopes-mismatch-error.js';
 import { SecurityHandlerError, createSecurityHandlerError } from './security-handler-error.js';
 import { UnauthorizedError, createUnauthorizedError } from './unauthorized-error.js';
 
 const errors = {
+  NotImplementedError,
   ScopesMismatchError,
   SecurityHandlerError,
   UnauthorizedError
 };
 
-export { createScopesMismatchError, createUnauthorizedError, createSecurityHandlerError, errors };
+export {
+  createScopesMismatchError,
+  createUnauthorizedError,
+  createNotImplementedError,
+  createSecurityHandlerError,
+  errors
+};

--- a/src/errors/not-implemented-error.js
+++ b/src/errors/not-implemented-error.js
@@ -1,0 +1,11 @@
+import createError from '@fastify/error';
+
+const NotImplementedError = createError('FST_OAS_NOT_IMPLEMENTED', 'Not implemented', 501);
+
+const createNotImplementedError = () => {
+  const err = new NotImplementedError();
+
+  return err;
+};
+
+export { NotImplementedError, createNotImplementedError };


### PR DESCRIPTION
This adds a mechanism to install handlers for routes from the spec that have not been registered with fastify and which will return a `not implemented` response.
The mechanism is by adding a `installNotImplementedRoutes` in the `oas` property that decorates `fastify` which must be called before calling `fastify.ready()`.